### PR TITLE
Fix gender field error and remove unique email.

### DIFF
--- a/src/main/java/com/example/WebApplication/member/Member.java
+++ b/src/main/java/com/example/WebApplication/member/Member.java
@@ -34,8 +34,7 @@ public class Member
 
     @NotEmpty(message = "email| Entrez votre adresse courriel.")
     @Email(message = "email| L'addresse courriel n'est pas valide.")
-    @Column(nullable = false,
-            unique = true)
+    @Column(nullable = false)
 
     private String email;
 

--- a/src/main/resources/static/src/script.js
+++ b/src/main/resources/static/src/script.js
@@ -8,6 +8,12 @@ const passedExam = document.querySelector('input[name="passedExam"]')
 const genderField = document.getElementById('gender')
 const message = document.getElementById('successMsg')
 const inputs = [firstName, lastName, birthDate, email]
+const genderFields = [
+    document.getElementById("female"),
+    document.getElementById("male"),
+    document.getElementById("other")
+]
+
 
 message.classList.add('hidden')
 let areInputsValid = false
@@ -15,8 +21,8 @@ let responseStatus;
 
 form.addEventListener('submit', (e) => {
     e.preventDefault();
-    inputs.forEach(validateInputs)
-    genderIsSelected()
+    // inputs.forEach(validateInputs)
+    // genderIsSelected()
     renderServerResponse()
 });
 
@@ -26,8 +32,10 @@ inputs.forEach(input => {
     });
 })
 
-genderField.addEventListener('change',() => {
-  genderIsSelected()
+genderFields.forEach(value => {
+    value.addEventListener('change', () => {
+        genderIsSelected()
+    })
 })
 
 function validateInputs(inputBox)

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -33,7 +33,7 @@
                 <div class="error-hint hidden">Ce champs est obligatoire.</div>
                 <div class="radio-box">
                     <p name="gender-selection" id="gender">Genre:</p>
-                    <div class="error-hint hidden">Ce champs est obligatoire.</div>
+                    <div class="error-hint hidden">Choisissez une option.</div>
                     <input type="radio" name="gender" id="female" value="FEMALE">
                     <label for="female">Female</label><br>
                     <input type="radio" name="gender" id="male" value="MALE">


### PR DESCRIPTION
Problem: 
 - The gender field was keeping the error message even after an option was selected.
 - The error message for gender field was not appropriate.
 - The @unique for email table was causing server error 500 for duplicated values.

Fix:
- Adding an event listener to check if any of the options were selected.
- Changed the error message to "Choisissez une option".
- Removed the @unique for now. Should be resolved when dealing with the TODO.
